### PR TITLE
Allow single file uploads (i.e. don't require files array)

### DIFF
--- a/server/api/submission/submission.controller.js
+++ b/server/api/submission/submission.controller.js
@@ -75,6 +75,9 @@ function saveSubmissionImage(files, fields, cb){
   var imagePaths = [],
       asyncTasks = [];
   if (!files){return imagePaths;}
+  if (!files.files.length){
+    files.files = [files.files];
+  }
   files.files.forEach(function(file) {
     var name = file.name,
         title = name.substr(0, name.lastIndexOf('.')),


### PR DESCRIPTION
React Native does not natively support (i.e. via XHR/fetch) support multiple file uploads (at the moment). This fix makes react native compatible with our upload system.
