### PR TITLE
Basic Server Scheduling

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -30,6 +30,7 @@ var socketio = require('socket.io')(server, {
 require('./config/socketio')(socketio);
 require('./config/express')(app);
 require('./routes')(app);
+require('./schedule').start(config);
 
 // Start server
 function startServer() {

--- a/server/schedule/index.js
+++ b/server/schedule/index.js
@@ -1,0 +1,70 @@
+/**
+ * Scheduling module. This module allows for scheduling of tasks on the site
+ * in a persistent way (i.e. surviving server restarts).
+ *
+ * Other modules can use the scheduler in the following manner...
+ *
+ * var scheduler = require("../../path/to/schedule");
+ *
+ * function handleSiteEvent(data){
+ * 		...
+ *   	scheduler.now("handle task", data);
+ *   	OR
+ *   	scheduler.schedule("tomorrow at 1pm", "handle task", data);
+ * 		...
+ * }
+ */
+
+var Agenda = require("agenda");
+var agenda = exports.agenda = null;
+
+var showMessageJob = require('./jobs/showMessage');
+
+function setupJobs(){
+  showMessageJob.setup(agenda);
+}
+
+function configurePeriodicJobs(){
+
+  // EXAMPLE JOB SCHEDULING
+  // agenda.every('5 seconds', 'show message');
+}
+
+/**
+ * Starts agenda listener and initializes job handlers.
+ * @param  {app config} config
+ */
+exports.start = (config) => {
+  agenda = exports.agenda = new Agenda({
+    db: {
+      address: config.mongo.uri,
+      collection: 'agendaJobs'
+    }
+  });
+
+  agenda.on('ready', function(){
+    setupJobs();
+    configurePeriodicJobs();
+  });
+
+  agenda.start();
+};
+
+/**
+ * Schedule a job to be performed ASAP
+ * @param  {string}   task   job name
+ * @param  {any}   params parameters to job
+ * @param  {Function} cb     called after job added to queue
+ * @return {Job} Agenda job object
+ */
+exports.now = (task, params, cb) => agenda.now(task, params, cb)
+
+/**
+ * Schedule a job to be performed at a designated time
+ * @param  {Date or stirng}   when   "tomorrow at noon" or Date()
+ * @param  {string}   task   job name
+ * @param  {any}   params parameters to job
+ * @param  {Function} cb     called after job added to queue
+ * @return {Job} Agenda job object
+ */
+exports.schedule = (when, task, params, cb) => agenda.schedule(when, task, params, cb);

--- a/server/schedule/jobs/showMessage.js
+++ b/server/schedule/jobs/showMessage.js
@@ -1,0 +1,11 @@
+exports.setup = (agenda) => {
+  agenda.define('show message', (job, done) => {
+    console.log("Shows message.");
+    done();
+  });
+
+  agenda.define('show message from site', (job, done) => {
+    console.log(`Showing message from site with params: ${job}`);
+    done();
+  });
+}


### PR DESCRIPTION
This is an implementation of basic server scheduling with agenda/mongodb.

This heavily leveraged @leej42's work on the `email-event-create` branch and [angular-fullstack agenda-schedule sample](https://github.com/usemodj/agenda-schedule).

An important difference between the approach taken in this PR and @leej42's approach is this approach executes a scheduler on the same process/machine as the express server. This is non-desirable in situations where the processing task is intensive or blocking, for the immediate future this shouldn't be a huge problem because this current method is compatible with workers in outside processes.

It might be worth considering moving the downscaling to a scheduler that runs on a separate machine later.
