### PR TITLE
Email Module Restructure

### DIFF
--- a/server/components/email/index.js
+++ b/server/components/email/index.js
@@ -1,28 +1,55 @@
 /**
- * Email Module. The email service to use is determined by the emailService
- * in the config.
- */
+* Allows sending of emails for various site services. The email service to use
+* is determined by the emailService specified in the application config.
+*/
+
+var config = require('../../config/environment');
+var fs = require('fs');
+var path = require('path');
+var signupTemplate = fs.readFileSync(path.join(__dirname,"templates","signup.html"), "utf8");
+var forgotPasswordTemplate = fs.readFileSync(path.join(__dirname,"templates","forgotPassword.html"), "utf8");
+
+var emailClient;
+switch(config.emailService){
+  case "SMTP":
+    emailClient = require("./smtp");
+    break;
+  case "SENDGRID":
+    emailClient = require("./sendgrid");
+    break;
+  case "MOCK":
+    emailClient = require("./mock");
+    console.log("USING MOCK EMAIL CLIENT");
+    break;
+  default:
+    emailClient = { send: () => console.error("No Email Service!") };
+}
+
 
 /**
  * Sends the initial signup email.
  * @param  {object}   message  {email, name, verifyURL}
  * @param  {Function} callback Function to call after queuing or sending email
  */
-module.exports.signup = (message, callback) => console.error("No Email Service!");
+ module.exports.signup = (message, callback) => {
+   callback = callback || function(){};
+   var templated = signupTemplate.replace(/\-name\-/g, message.name)
+                                 .replace(/\-verifyURL\-/g, message.verifyURL);
+   message.html = templated;
+   message.subject = "[Venue] Signup Verification";
+   emailClient.send(message, callback);
+ };
 
 /**
  * Sends a "forgot password" email.
  * @param  {object}   message  {email, name, verifyURL}
  * @param  {Function} callback Function to call after queuing or sending email
  */
-module.exports.forgotPassword = (message, callback) => console.error("No Email Service!");
-
-var config = require('../../config/environment');
-
-if (config.emailService == "SMTP"){
-  module.exports = require("./smtp");
-}else if (config.emailService == "SENDGRID"){
-  module.exports = require("./sendgrid");
-}else if (config.emailService == "MOCK"){
-  module.exports = require("./mock");
-}
+ module.exports.forgotPassword = (message, callback) => {
+   callback = callback || function(){};
+   var templated = forgotPasswordTemplate.replace(/\-name\-/g, message.name)
+                                         .replace(/\-verifyURL\-/g, message.verifyURL);
+   message.html = templated;
+   message.subject = "[Venue] Forgot Email";
+   emailClient.send(message, callback);
+ };

--- a/server/components/email/index.js
+++ b/server/components/email/index.js
@@ -1,48 +1,28 @@
+/**
+ * Email Module. The email service to use is determined by the emailService
+ * in the config.
+ */
+
+/**
+ * Sends the initial signup email.
+ * @param  {object}   message  {email, name, verifyURL}
+ * @param  {Function} callback Function to call after queuing or sending email
+ */
+module.exports.signup = (message, callback) => console.error("No Email Service!");
+
+/**
+ * Sends a "forgot password" email.
+ * @param  {object}   message  {email, name, verifyURL}
+ * @param  {Function} callback Function to call after queuing or sending email
+ */
+module.exports.forgotPassword = (message, callback) => console.error("No Email Service!");
+
 var config = require('../../config/environment');
-var sendgrid = require("sendgrid")(config.sendgridKey);
-var fs = require('fs');
-var path = require('path');
-var signupTemplate = fs.readFileSync(path.join(__dirname,"signup.html"), "utf8");
-var forgotPasswordTemplate = fs.readFileSync(path.join(__dirname,"forgotPassword.html"), "utf8");
 
-module.exports.signup = function(message, callback){
-  callback = callback || function(){};
-  var email = new sendgrid.Email();
-  email.addTo(message.email);
-  email.subject = "[Venue] Signup Verification";
-  email.from = config.serverEmail;
-  email.setHtml(signupTemplate); //pass in the string template we read from disk
-  email.addSubstitution("-name-", message.name); //sub. variables
-  email.addSubstitution("-verifyURL-", message.verifyURL); //sub. variables
-  sendEmail(email, callback)
-  if(process.env.NODE_ENV != "production") {
-    console.log(message.verifyURL);
-  }
+if (config.emailService == "SMTP"){
+  module.exports = require("./smtp");
+}else if (config.emailService == "SENDGRID"){
+  module.exports = require("./sendgrid");
+}else if (config.emailService == "MOCK"){
+  module.exports = require("./mock");
 }
-
-module.exports.forgotPassword = function(message, callback){
-  callback = callback || function(){};
-  var email = new sendgrid.Email();
-  email.addTo(message.email);
-  email.subject = "[Venue] Forgot Email";
-  email.from = config.serverEmail;
-  email.setHtml(forgotPasswordTemplate); //pass in the string template we read from disk
-  email.addSubstitution("-name-", message.name); //sub. variables
-  email.addSubstitution("-verifyURL-", message.verifyURL); //sub. variables
-  sendEmail(email, callback)
-  if(process.env.NODE_ENV != "production") {
-    console.log(message.verifyURL);
-  }
-}
-
-
-function sendEmail(email, callback){
-    sendgrid.send(email, function(err, json){
-        if (err){
-          callback("An error occurred sending the email");
-          console.error(err, json);
-        }else{
-          callback(null);
-        }
-    });
-};

--- a/server/components/email/mock/index.js
+++ b/server/components/email/mock/index.js
@@ -1,22 +1,5 @@
-var fs = require('fs');
-var path = require('path');
-var signupTemplate = fs.readFileSync(path.join(__dirname,"..","templates","signup.html"), "utf8");
-var forgotPasswordTemplate = fs.readFileSync(path.join(__dirname,"..","templates","forgotPassword.html"), "utf8");
-
-module.exports.signup = function(message, callback){
-  callback = callback || function(){};
-  console.log(`Sending ${message.email}`);
-  var templated = signupTemplate.replace(/\-name\-/g, message.name)
-                                .replace(/\-verifyURL\-/g, message.verifyURL);
-  console.log(`${templated}`);
-  callback();
-}
-
-module.exports.forgotPassword = function(message, callback){
-  callback = callback || function(){};
-  console.log(`Sending ${message.email}`);
-  var templated = forgotPasswordTemplate.replace(/\-name\-/g, message.name)
-                                        .replace(/\-verifyURL\-/g, message.verifyURL);
-  console.log(`${template}`);
-  callback();
-}
+module.exports.send = (message, callback) => {
+    console.log(`Sending ${message.email}`);
+    console.log(`${message.html}`);
+    callback();
+};

--- a/server/components/email/mock/index.js
+++ b/server/components/email/mock/index.js
@@ -1,0 +1,22 @@
+var fs = require('fs');
+var path = require('path');
+var signupTemplate = fs.readFileSync(path.join(__dirname,"..","templates","signup.html"), "utf8");
+var forgotPasswordTemplate = fs.readFileSync(path.join(__dirname,"..","templates","forgotPassword.html"), "utf8");
+
+module.exports.signup = function(message, callback){
+  callback = callback || function(){};
+  console.log(`Sending ${message.email}`);
+  var templated = signupTemplate.replace(/\-name\-/g, message.name)
+                                .replace(/\-verifyURL\-/g, message.verifyURL);
+  console.log(`${templated}`);
+  callback();
+}
+
+module.exports.forgotPassword = function(message, callback){
+  callback = callback || function(){};
+  console.log(`Sending ${message.email}`);
+  var templated = forgotPasswordTemplate.replace(/\-name\-/g, message.name)
+                                        .replace(/\-verifyURL\-/g, message.verifyURL);
+  console.log(`${template}`);
+  callback();
+}

--- a/server/components/email/sendgrid/index.js
+++ b/server/components/email/sendgrid/index.js
@@ -1,33 +1,14 @@
 var sendgrid = require("sendgrid")(config.sendgridKey);
-var fs = require('fs');
-var path = require('path');
-var signupTemplate = fs.readFileSync(path.join(__dirname,"..","templates","signup.html"), "utf8");
-var forgotPasswordTemplate = fs.readFileSync(path.join(__dirname,"..","templates","forgotPassword.html"), "utf8");
+var config = require('../../config/environment');
 
-module.exports.signup = function(message, callback){
-  callback = callback || function(){};
-  var email = new sendgrid.Email();
-  email.addTo(message.email);
-  email.subject = "[Venue] Signup Verification";
-  email.from = config.serverEmail;
-  email.setHtml(signupTemplate); //pass in the string template we read from disk
-  email.addSubstitution("-name-", message.name); //sub. variables
-  email.addSubstitution("-verifyURL-", message.verifyURL); //sub. variables
-  sendEmail(email, callback)
-}
-
-module.exports.forgotPassword = function(message, callback){
-  callback = callback || function(){};
-  var email = new sendgrid.Email();
-  email.addTo(message.email);
-  email.subject = "[Venue] Forgot Email";
-  email.from = config.serverEmail;
-  email.setHtml(forgotPasswordTemplate); //pass in the string template we read from disk
-  email.addSubstitution("-name-", message.name); //sub. variables
-  email.addSubstitution("-verifyURL-", message.verifyURL); //sub. variables
-  sendEmail(email, callback)
-}
-
+module.exports.send = (message, callback) => {
+    var email = sendgrid.Email();
+    email.addTo(message.email);
+    email.subject = message.subject;
+    email.from = config.serverEmail;
+    email.setHtml(message.html);
+    sendEmail(email, callback);
+};
 
 function sendEmail(email, callback){
     sendgrid.send(email, function(err, json){
@@ -38,4 +19,4 @@ function sendEmail(email, callback){
           callback(null);
         }
     });
-};
+}

--- a/server/components/email/sendgrid/index.js
+++ b/server/components/email/sendgrid/index.js
@@ -1,0 +1,41 @@
+var sendgrid = require("sendgrid")(config.sendgridKey);
+var fs = require('fs');
+var path = require('path');
+var signupTemplate = fs.readFileSync(path.join(__dirname,"..","templates","signup.html"), "utf8");
+var forgotPasswordTemplate = fs.readFileSync(path.join(__dirname,"..","templates","forgotPassword.html"), "utf8");
+
+module.exports.signup = function(message, callback){
+  callback = callback || function(){};
+  var email = new sendgrid.Email();
+  email.addTo(message.email);
+  email.subject = "[Venue] Signup Verification";
+  email.from = config.serverEmail;
+  email.setHtml(signupTemplate); //pass in the string template we read from disk
+  email.addSubstitution("-name-", message.name); //sub. variables
+  email.addSubstitution("-verifyURL-", message.verifyURL); //sub. variables
+  sendEmail(email, callback)
+}
+
+module.exports.forgotPassword = function(message, callback){
+  callback = callback || function(){};
+  var email = new sendgrid.Email();
+  email.addTo(message.email);
+  email.subject = "[Venue] Forgot Email";
+  email.from = config.serverEmail;
+  email.setHtml(forgotPasswordTemplate); //pass in the string template we read from disk
+  email.addSubstitution("-name-", message.name); //sub. variables
+  email.addSubstitution("-verifyURL-", message.verifyURL); //sub. variables
+  sendEmail(email, callback)
+}
+
+
+function sendEmail(email, callback){
+    sendgrid.send(email, function(err, json){
+        if (err){
+          callback("An error occurred sending the email");
+          console.error(err, json);
+        }else{
+          callback(null);
+        }
+    });
+};

--- a/server/components/email/templates/forgotPassword.html
+++ b/server/components/email/templates/forgotPassword.html
@@ -7,7 +7,7 @@
     <div>&nbsp;</div>
     <div>
       You forgot your password.
-      <a href=-verifyURL->Click here to reset</a>
+      <a href="-verifyURL-">Click here to reset</a>
     </div>
     <div>&nbsp;</div>
     <div>Good Luck</div>

--- a/server/components/email/templates/signup.html
+++ b/server/components/email/templates/signup.html
@@ -9,6 +9,6 @@
     <div>&nbsp;</div>
     <div>Best - Team Venue</div>
     <div>&nbsp;</div>
-    <a href=-verifyURL->Click here to verify</a>
+    <a href="-verifyURL-">Click here to verify</a>
   </body>
 </html>

--- a/server/config/environment/development.js
+++ b/server/config/environment/development.js
@@ -12,6 +12,9 @@ module.exports = {
   // Images Folder
   imageUploadPath: './data/',
 
+  // Just log outgoing emails
+  emailService: "MOCK",
+
   // Seed database on startup
   seedDB: true
 

--- a/server/config/environment/index.js
+++ b/server/config/environment/index.js
@@ -62,6 +62,10 @@ var all = {
     callbackURL:  (process.env.DOMAIN || '') + '/auth/google/callback'
   },
 
+  emailService: process.env.EMAIL_SERVICE,
+  smtpUsername: "",
+  smtpPassword: "",
+  smtpServer: "",
   sendgridKey: process.env.SENDGRID_KEY,
   serverEmail: process.env.SERVER_EMAIL
 };


### PR DESCRIPTION
This is the first step to getting smtp email and kind of cleaning up how email works.

Right now it's annoying to handle email in development. I've mitigated this by creating a `mock` email module and introducing a `emailService` to the config. This allows a dev to see the emails in their console.

This is just the first restructure, the next restructure will abstract away the forgotPassword/signup methods from sendgrid/smtp/mock and make them just `sendHTMLEmail` or `sendTextEmail` because that is much easier to maintain.
