### PR TITLE
provide digest arg to pbkdf2() for compatibility with node versions >= 6.x

### DIFF
--- a/server/api/user/user.model.js
+++ b/server/api/user/user.model.js
@@ -272,7 +272,7 @@ UserSchema.methods = {
                    .toString('base64');
     }
 
-    return crypto.pbkdf2(password, salt, defaultIterations, defaultKeyLength, (err, key) => {
+    return crypto.pbkdf2(password, salt, defaultIterations, defaultKeyLength, 'sha1', (err, key) => {
       if (err) {
         callback(err);
       } else {


### PR DESCRIPTION
This removes a deprecation warning with target node version 6.5 & fixes an error with node version 8.4. The "sha1" arg provides the same behavior as the call with no digest argument.